### PR TITLE
add support for Philippines.

### DIFF
--- a/country/data.go
+++ b/country/data.go
@@ -535,6 +535,11 @@ var (
 				bban.NewAccountNumber(16, bban.Num),
 			),
 		},
+		"PH": {
+			Name:       "Philippines",
+			Alpha2Code: "PH",
+			Alpha3Code: "PHL",
+		},
 		"PS": {
 			Name:       "Palestine",
 			Alpha2Code: "PS",


### PR DESCRIPTION
IBAN is rarely used in Philippines so adding swift support for now.